### PR TITLE
🐞 fix: JDBC 접근 오류 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     #url: jdbc:oracle:thin:@3.36.218.186:1522/xe
     #url: jdbc:mysql://192.168.0.10:3307/healingdog?useSSL=false&allowPublicKeyRetrieval=true
-    url: jdbc:mysql://localhost:3306/healingdog?useSSL=false&
+    url: jdbc:mysql://localhost:3306/healingdog?useSSL=false&allowPublicKeyRetrieval=true
     username: healingdog
     password: healingdog
   servlet:


### PR DESCRIPTION
DB 접근 시 Public Key Retrieval is not allowed 오류가 발생하며 연결에 실패하는 현상이 발생했습니다. MySQL 버전이 8.0 이상일 때 생길 수 있는 문제로, JDBC 접근 URL을 수정하여 해결했습니다.